### PR TITLE
fixing sampling attributes

### DIFF
--- a/cfno/data/preprocessing.py
+++ b/cfno/data/preprocessing.py
@@ -185,14 +185,16 @@ def createDataset(dataDir, inSize, outStep, inStep, outType, outScaling, dataFil
     xGrid, yGrid = outFiles.x, outFiles.y  # noqa: F841 (used lated by an eval call)
     
     try:
-        tBeg = int(kwargs['tBeg']/dtData)
-        nFields = int(kwargs['tEnd']/dtData)
+        iBeg = kwargs['iBeg']
+        iEnd = kwargs['iEnd']
+        nFields = iEnd-iBeg+1
+        sRange = range(iBeg, iEnd-inSize-outStep+1, inStep)
     except: 
         tBeg = 0
         nFields = sum(outFiles.nFields)
-    sRange = range(tBeg, nFields-inSize-outStep+1, inStep)
+        sRange = range(tBeg, nFields-inSize-outStep+1, inStep)
     nSamples = len(sRange)
-    print(f' {sRange},  outStep: {outStep}, inStep: {inStep}')
+    print(f'{sRange},  outStep: {outStep}, inStep: {inStep}')
     print(f"Creating dataset from {len(simDirs)} simulations, {nSamples} samples each ...")
     dataset = h5py.File(dataFile, "w")
     for name in ["inSize", "outStep", "inStep", "outType", "outScaling",

--- a/cfno/data/preprocessing.py
+++ b/cfno/data/preprocessing.py
@@ -168,13 +168,9 @@ class HDF5Dataset(Dataset):
 
 def createDataset(dataDir, inSize, outStep, inStep, outType, outScaling, dataFile,**kwargs):
     assert inSize == 1, "inSize != 1 not implemented yet ..."
-    simDirs = sorted(glob.glob(f"{dataDir}/simu_*"), key=lambda f: int(f.split('simu_',1)[1]))
-    if 'nSimu' in kwargs.keys():
-       nSimu = kwargs['nSimu']
-       simDirs = simDirs[:nSimu]
-    else:
-        nSimu = len(simDirs)
-    
+    simDirsSorted = sorted(glob.glob(f"{dataDir}/simu_*"), key=lambda f: int(f.split('simu_',1)[1]))
+    nSimu = int(kwargs.get("nSimu",len(simDirsSorted)))
+    simDirs = simDirsSorted[:nSimu]
     print(f'Using Simulations: {simDirs}')
     # -- retrieve informations from first simulation
     outFiles = OutputFiles(f"{simDirs[0]}/run_data")
@@ -184,15 +180,9 @@ def createDataset(dataDir, inSize, outStep, inStep, outType, outScaling, dataFil
     dtInput = dtData*outStep  # noqa: F841 (used lated by an eval call)
     xGrid, yGrid = outFiles.x, outFiles.y  # noqa: F841 (used lated by an eval call)
     
-    try:
-        iBeg = kwargs['iBeg']
-        iEnd = kwargs['iEnd']
-        nFields = iEnd-iBeg+1
-        sRange = range(iBeg, iEnd-inSize-outStep+1, inStep)
-    except: 
-        tBeg = 0
-        nFields = sum(outFiles.nFields)
-        sRange = range(tBeg, nFields-inSize-outStep+1, inStep)
+    iBeg = int(kwargs.get("iBeg", 0))
+    iEnd = int(kwargs.get("iEnd", sum(outFiles.nFields)))
+    sRange = range(iBeg, iEnd-inSize-outStep+1, inStep)
     nSamples = len(sRange)
     print(f'{sRange},  outStep: {outStep}, inStep: {inStep}')
     print(f"Creating dataset from {len(simDirs)} simulations, {nSamples} samples each ...")

--- a/scripts/02_sample.py
+++ b/scripts/02_sample.py
@@ -18,6 +18,10 @@ parser.add_argument(
 parser.add_argument(
     "--outStep", default=1, help="output step", type=int)
 parser.add_argument(
+    "--iBeg", default=0, help="starting index of data sample", type=int)
+parser.add_argument(
+    "--iEnd", help="stopping index of data sample", type=int)
+parser.add_argument(
     "--inStep", default=5, help="input step", type=int)
 parser.add_argument(
     "--outType", default="solution", help="output type in the dataset",
@@ -47,8 +51,6 @@ if args.config is not None:
     if "simu" in config and "dataDir" in config.simu:
         args.dataDir = config.simu.dataDir
         args.nSimu = config.simu.nSimu
-        args.tBeg = config.simu.tInit
-        args.tEnd = config.simu.tEnd
     if "data" in config:
         for key in ["outType", "outScaling", "dataFile"]:
             if key in config.data: args.__dict__[key] = config.data[key]


### PR DESCRIPTION
Added optional arguments `iBeg` and `iEnd` in `config.sample` to make it possible to sample subset of data from `run_data` simulation, else entire `run_data` simulation data is used.

Tested compatibility with [01_simu.py](https://github.com/Parallel-in-Time/cfno/blob/main/scripts/01_simu.py).